### PR TITLE
Enhance login redirect logic to preserve query parameters and hash

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,7 +11,10 @@ const LoginPage: React.FC = () => {
   const { login, error, isAuthenticated, isLoading } = useUser();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname || '/';
+  const fromLocation = location.state?.from; // Get the full 'from' location object
+  const redirectTo = fromLocation
+    ? `${fromLocation.pathname}${fromLocation.search || ''}${fromLocation.hash || ''}`
+    : '/';
   const { register, handleSubmit, formState: { errors: formErrors } } = useForm<LoginFormInputs>();
 
   const onSubmit: SubmitHandler<LoginFormInputs> = async (data) => {
@@ -22,9 +25,9 @@ const LoginPage: React.FC = () => {
   // Redirect if already authenticated
   React.useEffect(() => {
     if (isAuthenticated) {
-      navigate(from, { replace: true }); // Redirect to 'from' or '/'
+      navigate(redirectTo, { replace: true }); // Redirect to 'from' or '/'
     }
-  }, [isAuthenticated, navigate, from]);
+  }, [isAuthenticated, navigate, redirectTo]);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
The existing application already had a smart redirect feature that would send you to the login page if you accessed a protected route while unauthenticated, and then back to your original page after login.

This commit enhances this functionality by ensuring that any URL query parameters (e.g., ?id=123) and hash fragments (e.g., #section) from the originally requested URL are also preserved during this redirection process.

The changes were made in `src/pages/LoginPage.tsx` to reconstruct the full redirect path from the `location.state.from` object provided by `react-router-dom`.